### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/ghismary/weather-utils/compare/v0.2.0...v0.2.1) - 2024-12-02
+
+### Fixed
+
+- update repository links to GitHub

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weather-utils"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Ghislain MARY <ghislain@ghislainmary.fr>"]
 repository = "https://github.com/ghismary/weather-utils"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `weather-utils`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/ghismary/weather-utils/compare/v0.2.0...v0.2.1) - 2024-12-02

### Fixed

- update repository links to GitHub
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).