### PR TITLE
fix!: fix the spelling of unit names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,9 @@ impl<U: unit::TemperatureUnit> Temperature<U> {
         self.value.celsius()
     }
 
-    /// Get the temperature value in degrees Farenheit (°F).
-    pub fn farenheit(&self) -> f32 {
-        self.value.farenheit()
+    /// Get the temperature value in degrees Fahrenheit (°F).
+    pub fn fahrenheit(&self) -> f32 {
+        self.value.fahrenheit()
     }
 }
 
@@ -38,24 +38,24 @@ impl Temperature<unit::Celsius> {
     }
 }
 
-impl From<Temperature<unit::Farenheit>> for Temperature<unit::Celsius> {
-    fn from(value: Temperature<unit::Farenheit>) -> Self {
+impl From<Temperature<unit::Fahrenheit>> for Temperature<unit::Celsius> {
+    fn from(value: Temperature<unit::Fahrenheit>) -> Self {
         Self::new(value.celsius())
     }
 }
 
-impl Temperature<unit::Farenheit> {
-    /// Create a Farenheit temperature.
-    pub fn new(value: f32) -> Temperature<unit::Farenheit> {
+impl Temperature<unit::Fahrenheit> {
+    /// Create a Fahrenheit temperature.
+    pub fn new(value: f32) -> Temperature<unit::Fahrenheit> {
         Temperature {
-            value: unit::Farenheit { value },
+            value: unit::Fahrenheit { value },
         }
     }
 }
 
-impl From<Temperature<unit::Celsius>> for Temperature<unit::Farenheit> {
+impl From<Temperature<unit::Celsius>> for Temperature<unit::Fahrenheit> {
     fn from(value: Temperature<unit::Celsius>) -> Self {
-        Self::new(value.farenheit())
+        Self::new(value.fahrenheit())
     }
 }
 
@@ -105,32 +105,32 @@ impl TemperatureAndRelativeHumidity<unit::Celsius> {
     }
 }
 
-impl From<TemperatureAndRelativeHumidity<unit::Farenheit>>
+impl From<TemperatureAndRelativeHumidity<unit::Fahrenheit>>
     for TemperatureAndRelativeHumidity<unit::Celsius>
 {
-    fn from(value: TemperatureAndRelativeHumidity<unit::Farenheit>) -> Self {
+    fn from(value: TemperatureAndRelativeHumidity<unit::Fahrenheit>) -> Self {
         Self::new(value.temperature.celsius(), value.relative_humidity)
     }
 }
 
-impl TemperatureAndRelativeHumidity<unit::Farenheit> {
-    /// Create a combination of Farenheit temperature and relative humidity.
+impl TemperatureAndRelativeHumidity<unit::Fahrenheit> {
+    /// Create a combination of Fahrenheit temperature and relative humidity.
     pub fn new(
         temperature: f32,
         relative_humidity: f32,
-    ) -> TemperatureAndRelativeHumidity<unit::Farenheit> {
+    ) -> TemperatureAndRelativeHumidity<unit::Fahrenheit> {
         TemperatureAndRelativeHumidity {
             relative_humidity,
-            temperature: Temperature::<unit::Farenheit>::new(temperature),
+            temperature: Temperature::<unit::Fahrenheit>::new(temperature),
         }
     }
 }
 
 impl From<TemperatureAndRelativeHumidity<unit::Celsius>>
-    for TemperatureAndRelativeHumidity<unit::Farenheit>
+    for TemperatureAndRelativeHumidity<unit::Fahrenheit>
 {
     fn from(value: TemperatureAndRelativeHumidity<unit::Celsius>) -> Self {
-        Self::new(value.temperature.farenheit(), value.relative_humidity)
+        Self::new(value.temperature.fahrenheit(), value.relative_humidity)
     }
 }
 
@@ -165,32 +165,32 @@ impl TemperatureAndBarometricPressure<unit::Celsius> {
     }
 }
 
-impl From<TemperatureAndBarometricPressure<unit::Farenheit>>
+impl From<TemperatureAndBarometricPressure<unit::Fahrenheit>>
     for TemperatureAndBarometricPressure<unit::Celsius>
 {
-    fn from(value: TemperatureAndBarometricPressure<unit::Farenheit>) -> Self {
+    fn from(value: TemperatureAndBarometricPressure<unit::Fahrenheit>) -> Self {
         Self::new(value.temperature.celsius(), value.barometric_pressure)
     }
 }
 
-impl TemperatureAndBarometricPressure<unit::Farenheit> {
-    /// Create a combination of Farenheit temperature and barometric pressure.
+impl TemperatureAndBarometricPressure<unit::Fahrenheit> {
+    /// Create a combination of Fahrenheit temperature and barometric pressure.
     pub fn new(
         temperature: f32,
         barometric_pressure: f32,
-    ) -> TemperatureAndBarometricPressure<unit::Farenheit> {
+    ) -> TemperatureAndBarometricPressure<unit::Fahrenheit> {
         TemperatureAndBarometricPressure {
             barometric_pressure,
-            temperature: Temperature::<unit::Farenheit>::new(temperature),
+            temperature: Temperature::<unit::Fahrenheit>::new(temperature),
         }
     }
 }
 
 impl From<TemperatureAndBarometricPressure<unit::Celsius>>
-    for TemperatureAndBarometricPressure<unit::Farenheit>
+    for TemperatureAndBarometricPressure<unit::Fahrenheit>
 {
     fn from(value: TemperatureAndBarometricPressure<unit::Celsius>) -> Self {
-        Self::new(value.temperature.farenheit(), value.barometric_pressure)
+        Self::new(value.temperature.fahrenheit(), value.barometric_pressure)
     }
 }
 
@@ -208,7 +208,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (TemperatureAndRelativeHumidity::<Farenheit>::new(70.12, 45.59).absolute_humidity()
+            (TemperatureAndRelativeHumidity::<Fahrenheit>::new(70.12, 45.59).absolute_humidity()
                 - 8.43)
                 .abs()
                 < 0.01
@@ -220,7 +220,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (TemperatureAndRelativeHumidity::<Farenheit>::new(107.7, 74.91).absolute_humidity()
+            (TemperatureAndRelativeHumidity::<Fahrenheit>::new(107.7, 74.91).absolute_humidity()
                 - 42.49)
                 .abs()
                 < 0.01
@@ -254,7 +254,7 @@ mod tests {
     #[test]
     fn convert_temperatures() {
         assert!(
-            (Temperature::<Farenheit>::from(Temperature::<Celsius>::new(0.0))
+            (Temperature::<Fahrenheit>::from(Temperature::<Celsius>::new(0.0))
                 .value
                 .value
                 - 32.0)
@@ -262,7 +262,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (Temperature::<Farenheit>::from(Temperature::<Celsius>::new(15.73))
+            (Temperature::<Fahrenheit>::from(Temperature::<Celsius>::new(15.73))
                 .value
                 .value
                 - 60.31)
@@ -270,7 +270,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (Temperature::<Farenheit>::from(Temperature::<Celsius>::new(-7.49))
+            (Temperature::<Fahrenheit>::from(Temperature::<Celsius>::new(-7.49))
                 .value
                 .value
                 - 18.52)
@@ -278,7 +278,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (Temperature::<Farenheit>::from(Temperature::<Celsius>::new(37.5))
+            (Temperature::<Fahrenheit>::from(Temperature::<Celsius>::new(37.5))
                 .value
                 .value
                 - 99.5)
@@ -287,7 +287,7 @@ mod tests {
         );
 
         assert!(
-            (Temperature::<Celsius>::from(Temperature::<Farenheit>::new(32.0))
+            (Temperature::<Celsius>::from(Temperature::<Fahrenheit>::new(32.0))
                 .value
                 .value
                 - 0.0)
@@ -295,7 +295,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (Temperature::<Celsius>::from(Temperature::<Farenheit>::new(60.31))
+            (Temperature::<Celsius>::from(Temperature::<Fahrenheit>::new(60.31))
                 .value
                 .value
                 - 15.73)
@@ -303,7 +303,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (Temperature::<Celsius>::from(Temperature::<Farenheit>::new(18.52))
+            (Temperature::<Celsius>::from(Temperature::<Fahrenheit>::new(18.52))
                 .value
                 .value
                 - -7.49)
@@ -311,7 +311,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (Temperature::<Celsius>::from(Temperature::<Farenheit>::new(99.5))
+            (Temperature::<Celsius>::from(Temperature::<Fahrenheit>::new(99.5))
                 .value
                 .value
                 - 37.5)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,9 @@ pub struct Temperature<U: unit::TemperatureUnit> {
 }
 
 impl<U: unit::TemperatureUnit> Temperature<U> {
-    /// Get the temperature value in degrees Celcius (°C).
-    pub fn celcius(&self) -> f32 {
-        self.value.celcius()
+    /// Get the temperature value in degrees Celsius (°C).
+    pub fn celsius(&self) -> f32 {
+        self.value.celsius()
     }
 
     /// Get the temperature value in degrees Farenheit (°F).
@@ -29,18 +29,18 @@ impl<U: unit::TemperatureUnit> Temperature<U> {
     }
 }
 
-impl Temperature<unit::Celcius> {
-    /// Create a Celcius temperature.
-    pub fn new(value: f32) -> Temperature<unit::Celcius> {
+impl Temperature<unit::Celsius> {
+    /// Create a Celsius temperature.
+    pub fn new(value: f32) -> Temperature<unit::Celsius> {
         Temperature {
-            value: unit::Celcius { value },
+            value: unit::Celsius { value },
         }
     }
 }
 
-impl From<Temperature<unit::Farenheit>> for Temperature<unit::Celcius> {
+impl From<Temperature<unit::Farenheit>> for Temperature<unit::Celsius> {
     fn from(value: Temperature<unit::Farenheit>) -> Self {
-        Self::new(value.celcius())
+        Self::new(value.celsius())
     }
 }
 
@@ -53,8 +53,8 @@ impl Temperature<unit::Farenheit> {
     }
 }
 
-impl From<Temperature<unit::Celcius>> for Temperature<unit::Farenheit> {
-    fn from(value: Temperature<unit::Celcius>) -> Self {
+impl From<Temperature<unit::Celsius>> for Temperature<unit::Farenheit> {
+    fn from(value: Temperature<unit::Celsius>) -> Self {
         Self::new(value.farenheit())
     }
 }
@@ -83,7 +83,7 @@ pub struct TemperatureAndRelativeHumidity<U: unit::TemperatureUnit> {
 impl<U: unit::TemperatureUnit> TemperatureAndRelativeHumidity<U> {
     /// Computes the absolute humidity value (in g/m³).
     pub fn absolute_humidity(&self) -> AbsoluteHumidity {
-        let temperature = self.temperature.celcius();
+        let temperature = self.temperature.celsius();
         (6.112
             * ((17.67 * temperature) / (temperature + 243.5)).exp()
             * self.relative_humidity
@@ -92,24 +92,24 @@ impl<U: unit::TemperatureUnit> TemperatureAndRelativeHumidity<U> {
     }
 }
 
-impl TemperatureAndRelativeHumidity<unit::Celcius> {
-    /// Create a combination of Celcius temperature and relative humidity.
+impl TemperatureAndRelativeHumidity<unit::Celsius> {
+    /// Create a combination of Celsius temperature and relative humidity.
     pub fn new(
         temperature: f32,
         relative_humidity: f32,
-    ) -> TemperatureAndRelativeHumidity<unit::Celcius> {
+    ) -> TemperatureAndRelativeHumidity<unit::Celsius> {
         TemperatureAndRelativeHumidity {
             relative_humidity,
-            temperature: Temperature::<unit::Celcius>::new(temperature),
+            temperature: Temperature::<unit::Celsius>::new(temperature),
         }
     }
 }
 
 impl From<TemperatureAndRelativeHumidity<unit::Farenheit>>
-    for TemperatureAndRelativeHumidity<unit::Celcius>
+    for TemperatureAndRelativeHumidity<unit::Celsius>
 {
     fn from(value: TemperatureAndRelativeHumidity<unit::Farenheit>) -> Self {
-        Self::new(value.temperature.celcius(), value.relative_humidity)
+        Self::new(value.temperature.celsius(), value.relative_humidity)
     }
 }
 
@@ -126,10 +126,10 @@ impl TemperatureAndRelativeHumidity<unit::Farenheit> {
     }
 }
 
-impl From<TemperatureAndRelativeHumidity<unit::Celcius>>
+impl From<TemperatureAndRelativeHumidity<unit::Celsius>>
     for TemperatureAndRelativeHumidity<unit::Farenheit>
 {
-    fn from(value: TemperatureAndRelativeHumidity<unit::Celcius>) -> Self {
+    fn from(value: TemperatureAndRelativeHumidity<unit::Celsius>) -> Self {
         Self::new(value.temperature.farenheit(), value.relative_humidity)
     }
 }
@@ -146,30 +146,30 @@ pub struct TemperatureAndBarometricPressure<U: unit::TemperatureUnit> {
 impl<U: unit::TemperatureUnit> TemperatureAndBarometricPressure<U> {
     /// Compute the altitude (in m).
     pub fn altitude(&self) -> Altitude {
-        let temperature = self.temperature.celcius();
+        let temperature = self.temperature.celsius();
         ((1_013.25 / self.barometric_pressure).powf(1.0 / 5.257) - 1.0) * (temperature + 273.15)
             / 0.0065
     }
 }
 
-impl TemperatureAndBarometricPressure<unit::Celcius> {
-    /// Create a combination of Celcius temperature and barometric pressure.
+impl TemperatureAndBarometricPressure<unit::Celsius> {
+    /// Create a combination of Celsius temperature and barometric pressure.
     pub fn new(
         temperature: f32,
         barometric_pressure: f32,
-    ) -> TemperatureAndBarometricPressure<unit::Celcius> {
+    ) -> TemperatureAndBarometricPressure<unit::Celsius> {
         TemperatureAndBarometricPressure {
             barometric_pressure,
-            temperature: Temperature::<unit::Celcius>::new(temperature),
+            temperature: Temperature::<unit::Celsius>::new(temperature),
         }
     }
 }
 
 impl From<TemperatureAndBarometricPressure<unit::Farenheit>>
-    for TemperatureAndBarometricPressure<unit::Celcius>
+    for TemperatureAndBarometricPressure<unit::Celsius>
 {
     fn from(value: TemperatureAndBarometricPressure<unit::Farenheit>) -> Self {
-        Self::new(value.temperature.celcius(), value.barometric_pressure)
+        Self::new(value.temperature.celsius(), value.barometric_pressure)
     }
 }
 
@@ -186,10 +186,10 @@ impl TemperatureAndBarometricPressure<unit::Farenheit> {
     }
 }
 
-impl From<TemperatureAndBarometricPressure<unit::Celcius>>
+impl From<TemperatureAndBarometricPressure<unit::Celsius>>
     for TemperatureAndBarometricPressure<unit::Farenheit>
 {
-    fn from(value: TemperatureAndBarometricPressure<unit::Celcius>) -> Self {
+    fn from(value: TemperatureAndBarometricPressure<unit::Celsius>) -> Self {
         Self::new(value.temperature.farenheit(), value.barometric_pressure)
     }
 }
@@ -202,7 +202,7 @@ mod tests {
     #[test]
     fn compute_absolute_humidity() {
         assert!(
-            (TemperatureAndRelativeHumidity::<Celcius>::new(21.18, 45.59).absolute_humidity()
+            (TemperatureAndRelativeHumidity::<Celsius>::new(21.18, 45.59).absolute_humidity()
                 - 8.43)
                 .abs()
                 < 0.01
@@ -214,7 +214,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (TemperatureAndRelativeHumidity::<Celcius>::new(2.93, 34.71).absolute_humidity()
+            (TemperatureAndRelativeHumidity::<Celsius>::new(2.93, 34.71).absolute_humidity()
                 - 2.06)
                 .abs()
                 < 0.01
@@ -230,22 +230,22 @@ mod tests {
     #[test]
     fn compute_altitude() {
         assert!(
-            (TemperatureAndBarometricPressure::<Celcius>::new(20.55, 991.32).altitude() - 188.46)
+            (TemperatureAndBarometricPressure::<Celsius>::new(20.55, 991.32).altitude() - 188.46)
                 .abs()
                 < 0.01
         );
         assert!(
-            (TemperatureAndBarometricPressure::<Celcius>::new(17.93, 1013.25).altitude() - 0.0)
+            (TemperatureAndBarometricPressure::<Celsius>::new(17.93, 1013.25).altitude() - 0.0)
                 .abs()
                 < 0.01
         );
         assert!(
-            (TemperatureAndBarometricPressure::<Celcius>::new(37.5, 1013.25).altitude() - 0.0)
+            (TemperatureAndBarometricPressure::<Celsius>::new(37.5, 1013.25).altitude() - 0.0)
                 .abs()
                 < 0.01
         );
         assert!(
-            (TemperatureAndBarometricPressure::<Celcius>::new(19.37, 962.81).altitude() - 439.25)
+            (TemperatureAndBarometricPressure::<Celsius>::new(19.37, 962.81).altitude() - 439.25)
                 .abs()
                 < 0.01
         );
@@ -254,7 +254,7 @@ mod tests {
     #[test]
     fn convert_temperatures() {
         assert!(
-            (Temperature::<Farenheit>::from(Temperature::<Celcius>::new(0.0))
+            (Temperature::<Farenheit>::from(Temperature::<Celsius>::new(0.0))
                 .value
                 .value
                 - 32.0)
@@ -262,7 +262,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (Temperature::<Farenheit>::from(Temperature::<Celcius>::new(15.73))
+            (Temperature::<Farenheit>::from(Temperature::<Celsius>::new(15.73))
                 .value
                 .value
                 - 60.31)
@@ -270,7 +270,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (Temperature::<Farenheit>::from(Temperature::<Celcius>::new(-7.49))
+            (Temperature::<Farenheit>::from(Temperature::<Celsius>::new(-7.49))
                 .value
                 .value
                 - 18.52)
@@ -278,7 +278,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (Temperature::<Farenheit>::from(Temperature::<Celcius>::new(37.5))
+            (Temperature::<Farenheit>::from(Temperature::<Celsius>::new(37.5))
                 .value
                 .value
                 - 99.5)
@@ -287,7 +287,7 @@ mod tests {
         );
 
         assert!(
-            (Temperature::<Celcius>::from(Temperature::<Farenheit>::new(32.0))
+            (Temperature::<Celsius>::from(Temperature::<Farenheit>::new(32.0))
                 .value
                 .value
                 - 0.0)
@@ -295,7 +295,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (Temperature::<Celcius>::from(Temperature::<Farenheit>::new(60.31))
+            (Temperature::<Celsius>::from(Temperature::<Farenheit>::new(60.31))
                 .value
                 .value
                 - 15.73)
@@ -303,7 +303,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (Temperature::<Celcius>::from(Temperature::<Farenheit>::new(18.52))
+            (Temperature::<Celsius>::from(Temperature::<Farenheit>::new(18.52))
                 .value
                 .value
                 - -7.49)
@@ -311,7 +311,7 @@ mod tests {
                 < 0.01
         );
         assert!(
-            (Temperature::<Celcius>::from(Temperature::<Farenheit>::new(99.5))
+            (Temperature::<Celsius>::from(Temperature::<Farenheit>::new(99.5))
                 .value
                 .value
                 - 37.5)

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,24 +1,24 @@
 /// Trait defining the different ways to get a temperature.
 pub trait TemperatureUnit {
-    /// Get the temperature in degrees Celcius (°C).
-    fn celcius(&self) -> f32;
+    /// Get the temperature in degrees Celsius (°C).
+    fn celsius(&self) -> f32;
     /// Get the temperature in degrees Farenheit (°F).
     fn farenheit(&self) -> f32;
 }
 
-/// The degrees Celcius temperature unit.
+/// The degrees Celsius temperature unit.
 #[derive(Clone, Copy, Debug, Default)]
-pub struct Celcius {
+pub struct Celsius {
     pub(crate) value: f32,
 }
 
-impl TemperatureUnit for Celcius {
-    fn celcius(&self) -> f32 {
+impl TemperatureUnit for Celsius {
+    fn celsius(&self) -> f32 {
         self.value
     }
 
     fn farenheit(&self) -> f32 {
-        convert_celcius_to_farenheit(self.value)
+        convert_celsius_to_farenheit(self.value)
     }
 }
 
@@ -29,8 +29,8 @@ pub struct Farenheit {
 }
 
 impl TemperatureUnit for Farenheit {
-    fn celcius(&self) -> f32 {
-        convert_farenheit_to_celcius(self.value)
+    fn celsius(&self) -> f32 {
+        convert_farenheit_to_celsius(self.value)
     }
 
     fn farenheit(&self) -> f32 {
@@ -39,30 +39,30 @@ impl TemperatureUnit for Farenheit {
 }
 
 /// Converts a temperature in °C to °F.
-fn convert_celcius_to_farenheit(temperature: f32) -> f32 {
+fn convert_celsius_to_farenheit(temperature: f32) -> f32 {
     temperature * 1.8 + 32.0
 }
 
 /// Converts a temperature in °F to °C.
-fn convert_farenheit_to_celcius(temperature: f32) -> f32 {
+fn convert_farenheit_to_celsius(temperature: f32) -> f32 {
     (temperature - 32.0) * 0.55555
 }
 
 #[cfg(test)]
 mod tests {
     #[test]
-    fn convert_celcius_to_farenheit() {
-        assert!((super::convert_celcius_to_farenheit(0.0) - 32.0).abs() < 0.01);
-        assert!((super::convert_celcius_to_farenheit(15.73) - 60.31).abs() < 0.01);
-        assert!((super::convert_celcius_to_farenheit(-7.49) - 18.52).abs() < 0.01);
-        assert!((super::convert_celcius_to_farenheit(37.5) - 99.5).abs() < 0.01);
+    fn convert_celsius_to_farenheit() {
+        assert!((super::convert_celsius_to_farenheit(0.0) - 32.0).abs() < 0.01);
+        assert!((super::convert_celsius_to_farenheit(15.73) - 60.31).abs() < 0.01);
+        assert!((super::convert_celsius_to_farenheit(-7.49) - 18.52).abs() < 0.01);
+        assert!((super::convert_celsius_to_farenheit(37.5) - 99.5).abs() < 0.01);
     }
 
     #[test]
-    fn convert_farenheit_to_celcius() {
-        assert!((super::convert_farenheit_to_celcius(32.0) - 0.0).abs() < 0.01);
-        assert!((super::convert_farenheit_to_celcius(60.31) - 15.73).abs() < 0.01);
-        assert!((super::convert_farenheit_to_celcius(18.52) - -7.49).abs() < 0.01);
-        assert!((super::convert_farenheit_to_celcius(99.5) - 37.5).abs() < 0.01);
+    fn convert_farenheit_to_celsius() {
+        assert!((super::convert_farenheit_to_celsius(32.0) - 0.0).abs() < 0.01);
+        assert!((super::convert_farenheit_to_celsius(60.31) - 15.73).abs() < 0.01);
+        assert!((super::convert_farenheit_to_celsius(18.52) - -7.49).abs() < 0.01);
+        assert!((super::convert_farenheit_to_celsius(99.5) - 37.5).abs() < 0.01);
     }
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -2,8 +2,8 @@
 pub trait TemperatureUnit {
     /// Get the temperature in degrees Celsius (°C).
     fn celsius(&self) -> f32;
-    /// Get the temperature in degrees Farenheit (°F).
-    fn farenheit(&self) -> f32;
+    /// Get the temperature in degrees Fahrenheit (°F).
+    fn fahrenheit(&self) -> f32;
 }
 
 /// The degrees Celsius temperature unit.
@@ -17,52 +17,52 @@ impl TemperatureUnit for Celsius {
         self.value
     }
 
-    fn farenheit(&self) -> f32 {
-        convert_celsius_to_farenheit(self.value)
+    fn fahrenheit(&self) -> f32 {
+        convert_celsius_to_fahrenheit(self.value)
     }
 }
 
-/// The degrees Farenheit temperature unit.
+/// The degrees Fahrenheit temperature unit.
 #[derive(Clone, Copy, Debug, Default)]
-pub struct Farenheit {
+pub struct Fahrenheit {
     pub(crate) value: f32,
 }
 
-impl TemperatureUnit for Farenheit {
+impl TemperatureUnit for Fahrenheit {
     fn celsius(&self) -> f32 {
-        convert_farenheit_to_celsius(self.value)
+        convert_fahrenheit_to_celsius(self.value)
     }
 
-    fn farenheit(&self) -> f32 {
+    fn fahrenheit(&self) -> f32 {
         self.value
     }
 }
 
 /// Converts a temperature in °C to °F.
-fn convert_celsius_to_farenheit(temperature: f32) -> f32 {
+fn convert_celsius_to_fahrenheit(temperature: f32) -> f32 {
     temperature * 1.8 + 32.0
 }
 
 /// Converts a temperature in °F to °C.
-fn convert_farenheit_to_celsius(temperature: f32) -> f32 {
+fn convert_fahrenheit_to_celsius(temperature: f32) -> f32 {
     (temperature - 32.0) * 0.55555
 }
 
 #[cfg(test)]
 mod tests {
     #[test]
-    fn convert_celsius_to_farenheit() {
-        assert!((super::convert_celsius_to_farenheit(0.0) - 32.0).abs() < 0.01);
-        assert!((super::convert_celsius_to_farenheit(15.73) - 60.31).abs() < 0.01);
-        assert!((super::convert_celsius_to_farenheit(-7.49) - 18.52).abs() < 0.01);
-        assert!((super::convert_celsius_to_farenheit(37.5) - 99.5).abs() < 0.01);
+    fn convert_celsius_to_fahrenheit() {
+        assert!((super::convert_celsius_to_fahrenheit(0.0) - 32.0).abs() < 0.01);
+        assert!((super::convert_celsius_to_fahrenheit(15.73) - 60.31).abs() < 0.01);
+        assert!((super::convert_celsius_to_fahrenheit(-7.49) - 18.52).abs() < 0.01);
+        assert!((super::convert_celsius_to_fahrenheit(37.5) - 99.5).abs() < 0.01);
     }
 
     #[test]
-    fn convert_farenheit_to_celsius() {
-        assert!((super::convert_farenheit_to_celsius(32.0) - 0.0).abs() < 0.01);
-        assert!((super::convert_farenheit_to_celsius(60.31) - 15.73).abs() < 0.01);
-        assert!((super::convert_farenheit_to_celsius(18.52) - -7.49).abs() < 0.01);
-        assert!((super::convert_farenheit_to_celsius(99.5) - 37.5).abs() < 0.01);
+    fn convert_fahrenheit_to_celsius() {
+        assert!((super::convert_fahrenheit_to_celsius(32.0) - 0.0).abs() < 0.01);
+        assert!((super::convert_fahrenheit_to_celsius(60.31) - 15.73).abs() < 0.01);
+        assert!((super::convert_fahrenheit_to_celsius(18.52) - -7.49).abs() < 0.01);
+        assert!((super::convert_fahrenheit_to_celsius(99.5) - 37.5).abs() < 0.01);
     }
 }


### PR DESCRIPTION
Thanks for your work on this crate!

This fixes the spelling of "Celsius" and "Fahrenheit".
This would of course be a breaking change for this crate, which would later require updating https://github.com/ghismary/embedded-aht20.