### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/ghismary/weather-utils/compare/v0.2.1...v0.3.0) - 2025-02-03
+
+### Added
+
+- Add GitHub status badge and Codecov integration
+- Add PartialEq implementations & Improve tests
+
+### Fixed
+
+- [**breaking**] fix the spelling of "Fahrenheit"
+- [**breaking**] fix the spelling of "Celsius"
+
 ## [0.2.1](https://github.com/ghismary/weather-utils/compare/v0.2.0...v0.2.1) - 2024-12-02
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weather-utils"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Ghislain MARY <ghislain@ghislainmary.fr>"]
 repository = "https://github.com/ghismary/weather-utils"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `weather-utils`: 0.3.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/ghismary/weather-utils/compare/v0.2.1...v0.3.0) - 2025-02-03

### Added

- Add GitHub status badge and Codecov integration
- Add PartialEq implementations & Improve tests

### Fixed

- [**breaking**] fix the spelling of "Fahrenheit"
- [**breaking**] fix the spelling of "Celsius"
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).