### PR TITLE
feat: Add PartialEq implementations & Improve tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,8 @@ default = []
 no-std = ["micromath"]
 
 [dependencies]
-micromath = { version = "2.1.0", optional = true }
+approx = "0.5"
+micromath = { version = "2.1", optional = true }
+
+[dev-dependencies]
+rstest = "0.24"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(unsafe_code, missing_docs)]
 #![no_std]
 
+use approx::relative_eq;
 #[allow(unused_imports)]
 #[cfg(feature = "no-std")]
 use micromath::F32Ext;
@@ -29,18 +30,26 @@ impl<U: unit::TemperatureUnit> Temperature<U> {
     }
 }
 
+impl<U: unit::TemperatureUnit> PartialEq for Temperature<U> {
+    fn eq(&self, other: &Self) -> bool {
+        relative_eq!(self.celsius(), &other.celsius(), epsilon = 0.01)
+    }
+}
+
 impl Temperature<unit::Celsius> {
     /// Create a Celsius temperature.
     pub fn new(value: f32) -> Temperature<unit::Celsius> {
         Temperature {
-            value: unit::Celsius { value },
+            value: unit::Celsius(value),
         }
     }
 }
 
 impl From<Temperature<unit::Fahrenheit>> for Temperature<unit::Celsius> {
     fn from(value: Temperature<unit::Fahrenheit>) -> Self {
-        Self::new(value.celsius())
+        Self {
+            value: value.value.into(),
+        }
     }
 }
 
@@ -48,14 +57,16 @@ impl Temperature<unit::Fahrenheit> {
     /// Create a Fahrenheit temperature.
     pub fn new(value: f32) -> Temperature<unit::Fahrenheit> {
         Temperature {
-            value: unit::Fahrenheit { value },
+            value: unit::Fahrenheit(value),
         }
     }
 }
 
 impl From<Temperature<unit::Celsius>> for Temperature<unit::Fahrenheit> {
     fn from(value: Temperature<unit::Celsius>) -> Self {
-        Self::new(value.fahrenheit())
+        Self {
+            value: value.value.into(),
+        }
     }
 }
 
@@ -80,15 +91,22 @@ pub struct TemperatureAndRelativeHumidity<U: unit::TemperatureUnit> {
     pub temperature: Temperature<U>,
 }
 
+fn calculate_absolute_humidity(temperature: f32, relative_humidity: f32) -> f32 {
+    (6.112 * ((17.67 * temperature) / (temperature + 243.5)).exp() * relative_humidity * 2.1674)
+        / (273.15 + temperature)
+}
+
 impl<U: unit::TemperatureUnit> TemperatureAndRelativeHumidity<U> {
     /// Computes the absolute humidity value (in g/m³).
     pub fn absolute_humidity(&self) -> AbsoluteHumidity {
-        let temperature = self.temperature.celsius();
-        (6.112
-            * ((17.67 * temperature) / (temperature + 243.5)).exp()
-            * self.relative_humidity
-            * 2.1674)
-            / (273.15 + temperature)
+        calculate_absolute_humidity(self.temperature.celsius(), self.relative_humidity)
+    }
+}
+
+impl<U: unit::TemperatureUnit> PartialEq for TemperatureAndRelativeHumidity<U> {
+    fn eq(&self, other: &Self) -> bool {
+        relative_eq!(self.relative_humidity, other.relative_humidity)
+            && self.temperature.eq(&other.temperature)
     }
 }
 
@@ -135,7 +153,7 @@ impl From<TemperatureAndRelativeHumidity<unit::Celsius>>
 }
 
 /// The combination of the temperature and the barometric pressure.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct TemperatureAndBarometricPressure<U: unit::TemperatureUnit> {
     /// The barometric pressure (in hPa).
     pub barometric_pressure: BarometricPressure,
@@ -143,12 +161,14 @@ pub struct TemperatureAndBarometricPressure<U: unit::TemperatureUnit> {
     pub temperature: Temperature<U>,
 }
 
+fn calculate_altitude(temperature: f32, barometric_pressure: f32) -> f32 {
+    ((1_013.25 / barometric_pressure).powf(1.0 / 5.257) - 1.0) * (temperature + 273.15) / 0.0065
+}
+
 impl<U: unit::TemperatureUnit> TemperatureAndBarometricPressure<U> {
     /// Compute the altitude (in m).
     pub fn altitude(&self) -> Altitude {
-        let temperature = self.temperature.celsius();
-        ((1_013.25 / self.barometric_pressure).powf(1.0 / 5.257) - 1.0) * (temperature + 273.15)
-            / 0.0065
+        calculate_altitude(self.temperature.celsius(), self.barometric_pressure)
     }
 }
 
@@ -196,127 +216,115 @@ impl From<TemperatureAndBarometricPressure<unit::Celsius>>
 
 #[cfg(test)]
 mod tests {
-    use crate::unit::*;
-    use crate::*;
+    use super::*;
+    use crate::unit::{Celsius, Fahrenheit, TemperatureUnit};
+    use approx::assert_relative_eq;
+    use rstest::rstest;
 
-    #[test]
-    fn compute_absolute_humidity() {
-        assert!(
-            (TemperatureAndRelativeHumidity::<Celsius>::new(21.18, 45.59).absolute_humidity()
-                - 8.43)
-                .abs()
-                < 0.01
-        );
-        assert!(
-            (TemperatureAndRelativeHumidity::<Fahrenheit>::new(70.12, 45.59).absolute_humidity()
-                - 8.43)
-                .abs()
-                < 0.01
-        );
-        assert!(
-            (TemperatureAndRelativeHumidity::<Celsius>::new(2.93, 34.71).absolute_humidity()
-                - 2.06)
-                .abs()
-                < 0.01
-        );
-        assert!(
-            (TemperatureAndRelativeHumidity::<Fahrenheit>::new(107.7, 74.91).absolute_humidity()
-                - 42.49)
-                .abs()
-                < 0.01
+    #[rstest]
+    #[case(TemperatureAndRelativeHumidity::<Celsius>::new(21.18, 45.59), 8.43)]
+    #[case(TemperatureAndRelativeHumidity::<Fahrenheit>::new(70.12, 45.59), 8.43)]
+    #[case(TemperatureAndRelativeHumidity::<Celsius>::new(2.93, 34.71), 2.06)]
+    #[case(TemperatureAndRelativeHumidity::<Fahrenheit>::new(107.7, 74.91), 42.49)]
+    fn test_absolute_humidity_computation<U: TemperatureUnit>(
+        #[case] input: TemperatureAndRelativeHumidity<U>,
+        #[case] expected_absolute_humidity: AbsoluteHumidity,
+    ) {
+        assert_relative_eq!(
+            input.absolute_humidity(),
+            expected_absolute_humidity,
+            epsilon = 0.01
         );
     }
 
-    #[test]
-    fn compute_altitude() {
-        assert!(
-            (TemperatureAndBarometricPressure::<Celsius>::new(20.55, 991.32).altitude() - 188.46)
-                .abs()
-                < 0.01
-        );
-        assert!(
-            (TemperatureAndBarometricPressure::<Celsius>::new(17.93, 1013.25).altitude() - 0.0)
-                .abs()
-                < 0.01
-        );
-        assert!(
-            (TemperatureAndBarometricPressure::<Celsius>::new(37.5, 1013.25).altitude() - 0.0)
-                .abs()
-                < 0.01
-        );
-        assert!(
-            (TemperatureAndBarometricPressure::<Celsius>::new(19.37, 962.81).altitude() - 439.25)
-                .abs()
-                < 0.01
-        );
+    #[rstest]
+    #[case(TemperatureAndBarometricPressure::<Celsius>::new(20.55, 991.32), 188.46)]
+    #[case(TemperatureAndBarometricPressure::<Celsius>::new(17.93, 1013.25), 0.0)]
+    #[case(TemperatureAndBarometricPressure::<Celsius>::new(37.5, 1013.25), 0.0)]
+    #[case(TemperatureAndBarometricPressure::<Celsius>::new(19.37, 962.81), 439.25)]
+    #[case(TemperatureAndBarometricPressure::<Fahrenheit>::new(99.5, 1013.25), 0.0)]
+    fn test_altitude_computation<U: TemperatureUnit>(
+        #[case] input: TemperatureAndBarometricPressure<U>,
+        #[case] expected_altitude: Altitude,
+    ) {
+        assert_relative_eq!(input.altitude(), expected_altitude, epsilon = 0.01);
     }
 
-    #[test]
-    fn convert_temperatures() {
-        assert!(
-            (Temperature::<Fahrenheit>::from(Temperature::<Celsius>::new(0.0))
-                .value
-                .value
-                - 32.0)
-                .abs()
-                < 0.01
+    #[rstest]
+    #[case(0.0, 32.0)]
+    #[case(15.73, 60.31)]
+    #[case(-7.49, 18.52)]
+    #[case(37.5, 99.5)]
+    fn test_celsius_to_fahrenheit_temperature_conversion(
+        #[case] input: f32,
+        #[case] expected_fahrenheit: f32,
+    ) {
+        let temperature: Temperature<Fahrenheit> = Temperature::<Celsius>::new(input).into();
+        assert_relative_eq!(temperature.value.0, expected_fahrenheit, epsilon = 0.01);
+        assert_relative_eq!(
+            temperature.fahrenheit(),
+            expected_fahrenheit,
+            epsilon = 0.01
         );
-        assert!(
-            (Temperature::<Fahrenheit>::from(Temperature::<Celsius>::new(15.73))
-                .value
-                .value
-                - 60.31)
-                .abs()
-                < 0.01
-        );
-        assert!(
-            (Temperature::<Fahrenheit>::from(Temperature::<Celsius>::new(-7.49))
-                .value
-                .value
-                - 18.52)
-                .abs()
-                < 0.01
-        );
-        assert!(
-            (Temperature::<Fahrenheit>::from(Temperature::<Celsius>::new(37.5))
-                .value
-                .value
-                - 99.5)
-                .abs()
-                < 0.01
-        );
+        assert_relative_eq!(temperature.celsius(), input, epsilon = 0.01);
+    }
 
-        assert!(
-            (Temperature::<Celsius>::from(Temperature::<Fahrenheit>::new(32.0))
-                .value
-                .value
-                - 0.0)
-                .abs()
-                < 0.01
-        );
-        assert!(
-            (Temperature::<Celsius>::from(Temperature::<Fahrenheit>::new(60.31))
-                .value
-                .value
-                - 15.73)
-                .abs()
-                < 0.01
-        );
-        assert!(
-            (Temperature::<Celsius>::from(Temperature::<Fahrenheit>::new(18.52))
-                .value
-                .value
-                - -7.49)
-                .abs()
-                < 0.01
-        );
-        assert!(
-            (Temperature::<Celsius>::from(Temperature::<Fahrenheit>::new(99.5))
-                .value
-                .value
-                - 37.5)
-                .abs()
-                < 0.01
-        );
+    #[rstest]
+    #[case(32.0, 0.0)]
+    #[case(60.31, 15.73)]
+    #[case(18.52, -7.49)]
+    #[case(99.5, 37.5)]
+    fn test_fahrenheit_to_celsius_temperature_conversion(
+        #[case] input: f32,
+        #[case] expected_celsius: f32,
+    ) {
+        let temperature: Temperature<Celsius> = Temperature::<Fahrenheit>::new(input).into();
+        assert_relative_eq!(temperature.value.0, expected_celsius, epsilon = 0.01);
+        assert_relative_eq!(temperature.celsius(), expected_celsius, epsilon = 0.01);
+        assert_relative_eq!(temperature.fahrenheit(), input, epsilon = 0.01);
+    }
+
+    #[rstest]
+    #[case(TemperatureAndRelativeHumidity::<Celsius>::new(21.18, 45.59), TemperatureAndRelativeHumidity::<Fahrenheit>::new(70.12, 45.59))]
+    #[case(TemperatureAndRelativeHumidity::<Celsius>::new(-7.49, 73.19), TemperatureAndRelativeHumidity::<Fahrenheit>::new(18.52, 73.19))]
+    fn test_temperature_and_relative_humidity_celsius_to_fahrenheit_conversion(
+        #[case] input: TemperatureAndRelativeHumidity<Celsius>,
+        #[case] expected: TemperatureAndRelativeHumidity<Fahrenheit>,
+    ) {
+        let value: TemperatureAndRelativeHumidity<Fahrenheit> = input.into();
+        assert_eq!(value, expected);
+    }
+
+    #[rstest]
+    #[case(TemperatureAndRelativeHumidity::<Fahrenheit>::new(70.12, 45.59), TemperatureAndRelativeHumidity::<Celsius>::new(21.18, 45.59))]
+    #[case(TemperatureAndRelativeHumidity::<Fahrenheit>::new(18.52, 73.19), TemperatureAndRelativeHumidity::<Celsius>::new(-7.49, 73.19))]
+    fn test_temperature_and_relative_humidity_fahrenheit_to_celsius_conversion(
+        #[case] input: TemperatureAndRelativeHumidity<Fahrenheit>,
+        #[case] expected: TemperatureAndRelativeHumidity<Celsius>,
+    ) {
+        let value: TemperatureAndRelativeHumidity<Celsius> = input.into();
+        assert_eq!(value, expected);
+    }
+
+    #[rstest]
+    #[case(TemperatureAndBarometricPressure::<Celsius>::new(21.18, 991.32), TemperatureAndBarometricPressure::<Fahrenheit>::new(70.12, 991.32))]
+    #[case(TemperatureAndBarometricPressure::<Celsius>::new(37.5, 1013.25), TemperatureAndBarometricPressure::<Fahrenheit>::new(99.5, 1013.25))]
+    fn test_temperature_and_barometric_pressure_celsius_to_fahrenheit_conversion(
+        #[case] input: TemperatureAndBarometricPressure<Celsius>,
+        #[case] expected: TemperatureAndBarometricPressure<Fahrenheit>,
+    ) {
+        let value: TemperatureAndBarometricPressure<Fahrenheit> = input.into();
+        assert_eq!(value, expected);
+    }
+
+    #[rstest]
+    #[case(TemperatureAndBarometricPressure::<Fahrenheit>::new(70.12, 991.32), TemperatureAndBarometricPressure::<Celsius>::new(21.18, 991.32))]
+    #[case(TemperatureAndBarometricPressure::<Fahrenheit>::new(99.5, 1013.25), TemperatureAndBarometricPressure::<Celsius>::new(37.5, 1013.25))]
+    fn test_temperature_and_barometric_pressure_fahrenheit_to_celsius_conversion(
+        #[case] input: TemperatureAndBarometricPressure<Fahrenheit>,
+        #[case] expected: TemperatureAndBarometricPressure<Celsius>,
+    ) {
+        let value: TemperatureAndBarometricPressure<Celsius> = input.into();
+        assert_eq!(value, expected);
     }
 }

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,3 +1,5 @@
+use approx::relative_eq;
+
 /// Trait defining the different ways to get a temperature.
 pub trait TemperatureUnit {
     /// Get the temperature in degrees Celsius (°C).
@@ -8,33 +10,53 @@ pub trait TemperatureUnit {
 
 /// The degrees Celsius temperature unit.
 #[derive(Clone, Copy, Debug, Default)]
-pub struct Celsius {
-    pub(crate) value: f32,
-}
+pub struct Celsius(pub f32);
 
 impl TemperatureUnit for Celsius {
     fn celsius(&self) -> f32 {
-        self.value
+        self.0
     }
 
     fn fahrenheit(&self) -> f32 {
-        convert_celsius_to_fahrenheit(self.value)
+        convert_celsius_to_fahrenheit(self.0)
+    }
+}
+
+impl From<Fahrenheit> for Celsius {
+    fn from(value: Fahrenheit) -> Self {
+        Self(convert_fahrenheit_to_celsius(value.0))
+    }
+}
+
+impl PartialEq for Celsius {
+    fn eq(&self, other: &Self) -> bool {
+        relative_eq!(self.0, other.0, epsilon = 0.01)
     }
 }
 
 /// The degrees Fahrenheit temperature unit.
 #[derive(Clone, Copy, Debug, Default)]
-pub struct Fahrenheit {
-    pub(crate) value: f32,
-}
+pub struct Fahrenheit(pub f32);
 
 impl TemperatureUnit for Fahrenheit {
     fn celsius(&self) -> f32 {
-        convert_fahrenheit_to_celsius(self.value)
+        convert_fahrenheit_to_celsius(self.0)
     }
 
     fn fahrenheit(&self) -> f32 {
-        self.value
+        self.0
+    }
+}
+
+impl From<Celsius> for Fahrenheit {
+    fn from(value: Celsius) -> Self {
+        Self(convert_celsius_to_fahrenheit(value.0))
+    }
+}
+
+impl PartialEq for Fahrenheit {
+    fn eq(&self, other: &Self) -> bool {
+        relative_eq!(self.0, other.0, epsilon = 0.01)
     }
 }
 
@@ -50,19 +72,91 @@ fn convert_fahrenheit_to_celsius(temperature: f32) -> f32 {
 
 #[cfg(test)]
 mod tests {
-    #[test]
-    fn convert_celsius_to_fahrenheit() {
-        assert!((super::convert_celsius_to_fahrenheit(0.0) - 32.0).abs() < 0.01);
-        assert!((super::convert_celsius_to_fahrenheit(15.73) - 60.31).abs() < 0.01);
-        assert!((super::convert_celsius_to_fahrenheit(-7.49) - 18.52).abs() < 0.01);
-        assert!((super::convert_celsius_to_fahrenheit(37.5) - 99.5).abs() < 0.01);
+    use super::*;
+    use approx::assert_relative_eq;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(0.0, 32.0)]
+    #[case(15.73, 60.31)]
+    #[case(-7.49, 18.52)]
+    #[case(37.5, 99.5)]
+    fn test_celcius_to_fahrenheit_conversion(#[case] input: f32, #[case] expected_output: f32) {
+        assert_relative_eq!(
+            convert_celsius_to_fahrenheit(input),
+            expected_output,
+            epsilon = 0.01
+        );
     }
 
-    #[test]
-    fn convert_fahrenheit_to_celsius() {
-        assert!((super::convert_fahrenheit_to_celsius(32.0) - 0.0).abs() < 0.01);
-        assert!((super::convert_fahrenheit_to_celsius(60.31) - 15.73).abs() < 0.01);
-        assert!((super::convert_fahrenheit_to_celsius(18.52) - -7.49).abs() < 0.01);
-        assert!((super::convert_fahrenheit_to_celsius(99.5) - 37.5).abs() < 0.01);
+    #[rstest]
+    #[case(32.0, 0.0)]
+    #[case(60.31, 15.73)]
+    #[case(18.52, -7.49)]
+    #[case(99.5, 37.5)]
+    fn test_fahrenheit_to_celsius_conversion(#[case] input: f32, #[case] expected_output: f32) {
+        assert_relative_eq!(
+            convert_fahrenheit_to_celsius(input),
+            expected_output,
+            epsilon = 0.01
+        )
+    }
+
+    #[rstest]
+    #[case(0.0, 32.0)]
+    #[case(15.73, 60.31)]
+    #[case(-7.49, 18.52)]
+    #[case(37.5, 99.5)]
+    fn test_celsius(#[case] celsius: f32, #[case] expected_fahrenheit: f32) {
+        let temperature = Celsius(celsius);
+        assert_relative_eq!(temperature.celsius(), celsius, epsilon = f32::EPSILON);
+        assert_relative_eq!(
+            temperature.fahrenheit(),
+            expected_fahrenheit,
+            epsilon = 0.01
+        );
+    }
+
+    #[rstest]
+    #[case(32.0, 0.0)]
+    #[case(60.31, 15.73)]
+    #[case(18.52, -7.49)]
+    #[case(99.5, 37.5)]
+    fn test_fahrenheit(#[case] fahrenheit: f32, #[case] expected_celsius: f32) {
+        let temperature = Fahrenheit(fahrenheit);
+        assert_relative_eq!(temperature.fahrenheit(), fahrenheit, epsilon = f32::EPSILON);
+        assert_relative_eq!(temperature.celsius(), expected_celsius, epsilon = 0.01);
+    }
+
+    #[rstest]
+    #[case(0.0, 0.001)]
+    #[case(0.004, 0.0)]
+    #[case(15.73, 15.728)]
+    fn test_celsius_eq(#[case] a: f32, #[case] b: f32) {
+        assert_eq!(Celsius(a), Celsius(b));
+    }
+
+    #[rstest]
+    #[case(0.0, 10.3)]
+    #[case(0.0, 0.09)]
+    #[case(37.5, 38.9)]
+    fn test_celsius_ne(#[case] a: f32, #[case] b: f32) {
+        assert_ne!(Celsius(a), Celsius(b))
+    }
+
+    #[rstest]
+    #[case(32.0, 32.001)]
+    #[case(32.004, 32.0)]
+    #[case(60.31, 60.308)]
+    fn test_fahrenheit_eq(#[case] a: f32, #[case] b: f32) {
+        assert_eq!(Fahrenheit(a), Fahrenheit(b));
+    }
+
+    #[rstest]
+    #[case(0.0, 10.3)]
+    #[case(0.0, 0.09)]
+    #[case(99.5, 100.9)]
+    fn test_fahrenheit_ne(#[case] a: f32, #[case] b: f32) {
+        assert_ne!(Fahrenheit(a), Fahrenheit(b))
     }
 }


### PR DESCRIPTION
Add PartialEq implementation for all types.
Updates dependencies to include `approx` for improved floating-point comparisons and adds `rstest` for parameterized testing. Refactors tests to use `rstest` and `approx` for more concise and reliable assertions, enhancing overall test coverage and maintainability.