### PR TITLE
feat: Add GitHub status badge and Codecov integration

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -42,4 +42,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Generate code coverage
         run: |
-          cargo tarpaulin --verbose --workspace
+          cargo tarpaulin --workspace --out Xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![crates.io](https://img.shields.io/crates/v/weather-utils.svg)](https://crates.io/crates/weather-utils)
+[![Github status](https://github.com/ghismary/weather-utils/actions/workflows/general.yml/badge.svg)](https://github.com/ghismary/weather-utils)
+[![codecov](https://codecov.io/gh/ghismary/weather-utils/graph/badge.svg?token=EBQTUEQUK1)](https://codecov.io/gh/ghismary/weather-utils)
 [![License](https://img.shields.io/crates/l/weather-utils.svg)](https://crates.io/crates/weather-utils)
 [![Documentation](https://docs.rs/weather-utils/badge.svg)](https://docs.rs/weather-utils)
 


### PR DESCRIPTION
Adds a GitHub status badge to the README for better visibility of CI status. Updates the GitHub Actions workflow to include Codecov integration for code coverage reporting, enhancing the project's quality assurance process.