### PR TITLE
chore: Use newtype pattern for `BarometricPressure` and `Altitude`

### DIFF
--- a/src/pressure.rs
+++ b/src/pressure.rs
@@ -4,16 +4,58 @@ use micromath::F32Ext;
 #[cfg(not(feature = "no-std"))]
 extern crate std;
 
+use approx::relative_eq;
+
 use crate::{Celsius, Fahrenheit, Temperature};
 
 /// The barometric pressure type (in hPa).
-pub type BarometricPressure = f32;
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BarometricPressure(pub f32);
+
+impl BarometricPressure {
+    /// Get the value of the barometric pressure.
+    pub fn value(&self) -> f32 {
+        self.0
+    }
+}
+
+impl From<f32> for BarometricPressure {
+    fn from(value: f32) -> Self {
+        Self(value)
+    }
+}
+
+impl PartialEq for BarometricPressure {
+    fn eq(&self, other: &Self) -> bool {
+        relative_eq!(self.0, other.0, epsilon = 0.01)
+    }
+}
 
 /// The altitude type (in m).
-pub type Altitude = f32;
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Altitude(pub f32);
+
+impl Altitude {
+    /// Get the value of the altitude.
+    pub fn value(&self) -> f32 {
+        self.0
+    }
+}
+
+impl From<f32> for Altitude {
+    fn from(value: f32) -> Self {
+        Self(value)
+    }
+}
+
+impl PartialEq for Altitude {
+    fn eq(&self, other: &Self) -> bool {
+        relative_eq!(self.0, other.0, epsilon = 0.01)
+    }
+}
 
 /// The combination of the temperature and the barometric pressure.
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct TemperatureAndBarometricPressure<T: Temperature> {
     /// The temperature (either in °C or °F).
     pub temperature: T,
@@ -24,9 +66,18 @@ pub struct TemperatureAndBarometricPressure<T: Temperature> {
 impl<T: Temperature> TemperatureAndBarometricPressure<T> {
     /// Compute the altitude (in m).
     pub fn altitude(&self) -> Altitude {
-        ((1_013.25 / self.barometric_pressure).powf(1.0 / 5.257) - 1.0)
-            * (self.temperature.celsius().value() + 273.15)
-            / 0.0065
+        Altitude(
+            ((1_013.25 / self.barometric_pressure.value()).powf(1.0 / 5.257) - 1.0)
+                * (self.temperature.celsius().value() + 273.15)
+                / 0.0065,
+        )
+    }
+}
+
+impl<T: Temperature + PartialEq> PartialEq for TemperatureAndBarometricPressure<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.barometric_pressure.eq(&other.barometric_pressure)
+            && self.temperature.eq(&other.temperature)
     }
 }
 
@@ -60,21 +111,32 @@ mod tests {
     use super::*;
 
     #[rstest]
-    #[case(TemperatureAndBarometricPressure{ temperature: Celsius(20.55), barometric_pressure: 991.32 }, 188.46)]
-    #[case(TemperatureAndBarometricPressure{ temperature: Celsius(17.93), barometric_pressure: 1013.25 }, 0.0)]
-    #[case(TemperatureAndBarometricPressure{ temperature: Celsius(37.5), barometric_pressure: 1013.25 }, 0.0)]
-    #[case(TemperatureAndBarometricPressure{ temperature: Celsius(19.37), barometric_pressure: 962.81 }, 439.25)]
-    #[case(TemperatureAndBarometricPressure{ temperature: Fahrenheit(99.5), barometric_pressure: 1013.25 }, 0.0)]
+    #[case(TemperatureAndBarometricPressure{ temperature: Celsius(20.55), barometric_pressure: BarometricPressure(991.32) }, Altitude(188.46))]
+    #[case(TemperatureAndBarometricPressure{ temperature: Celsius(17.93), barometric_pressure: 1013.25.into() }, 0.0.into())]
+    #[case(TemperatureAndBarometricPressure{ temperature: Celsius(37.5), barometric_pressure: BarometricPressure(1013.25) }, Altitude(0.0))]
+    #[case(TemperatureAndBarometricPressure{ temperature: Celsius(19.37), barometric_pressure: 962.81.into() }, 439.25.into())]
+    #[case(TemperatureAndBarometricPressure{ temperature: Fahrenheit(99.5), barometric_pressure: BarometricPressure(1013.25) }, Altitude(0.0))]
     fn test_altitude_computation<T: Temperature>(
         #[case] input: TemperatureAndBarometricPressure<T>,
         #[case] expected_altitude: Altitude,
     ) {
-        assert_relative_eq!(input.altitude(), expected_altitude, epsilon = 0.01);
+        assert_eq!(input.altitude(), expected_altitude);
+        assert_relative_eq!(
+            input.altitude().value(),
+            expected_altitude.value(),
+            epsilon = 0.01
+        );
     }
 
     #[rstest]
-    #[case(TemperatureAndBarometricPressure{ temperature: Celsius(21.18), barometric_pressure: 991.32 }, TemperatureAndBarometricPressure{ temperature: Fahrenheit(70.12), barometric_pressure: 991.32 })]
-    #[case(TemperatureAndBarometricPressure{ temperature: Celsius(37.5), barometric_pressure: 1013.25 }, TemperatureAndBarometricPressure{ temperature: Fahrenheit(99.5), barometric_pressure: 1013.25 })]
+    #[case(
+        TemperatureAndBarometricPressure{ temperature: Celsius(21.18), barometric_pressure: BarometricPressure(991.32) },
+        TemperatureAndBarometricPressure{ temperature: Fahrenheit(70.12), barometric_pressure: 991.32.into() }
+    )]
+    #[case(
+        TemperatureAndBarometricPressure{ temperature: Celsius(37.5), barometric_pressure: 1013.25.into() },
+        TemperatureAndBarometricPressure{ temperature: Fahrenheit(99.5), barometric_pressure: BarometricPressure(1013.25) }
+    )]
     fn test_temperature_and_barometric_pressure_celsius_to_fahrenheit_conversion(
         #[case] input: TemperatureAndBarometricPressure<Celsius>,
         #[case] expected: TemperatureAndBarometricPressure<Fahrenheit>,
@@ -84,8 +146,14 @@ mod tests {
     }
 
     #[rstest]
-    #[case(TemperatureAndBarometricPressure{ temperature: Fahrenheit(70.12), barometric_pressure: 991.32 }, TemperatureAndBarometricPressure{ temperature: Celsius(21.18), barometric_pressure: 991.32 })]
-    #[case(TemperatureAndBarometricPressure{ temperature: Fahrenheit(99.5), barometric_pressure: 1013.25 }, TemperatureAndBarometricPressure{ temperature: Celsius(37.5), barometric_pressure: 1013.25 })]
+    #[case(
+        TemperatureAndBarometricPressure{ temperature: Fahrenheit(70.12), barometric_pressure: BarometricPressure(991.32) },
+        TemperatureAndBarometricPressure{ temperature: Celsius(21.18), barometric_pressure: 991.32.into() }
+    )]
+    #[case(
+        TemperatureAndBarometricPressure{ temperature: Fahrenheit(99.5), barometric_pressure: 1013.25.into() },
+        TemperatureAndBarometricPressure{ temperature: Celsius(37.5), barometric_pressure: BarometricPressure(1013.25) }
+    )]
     fn test_temperature_and_barometric_pressure_fahrenheit_to_celsius_conversion(
         #[case] input: TemperatureAndBarometricPressure<Fahrenheit>,
         #[case] expected: TemperatureAndBarometricPressure<Celsius>,


### PR DESCRIPTION
This enables the implementation of the `PartialEq` trait that eases the comparison of these types.