### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/ghismary/weather-utils/compare/v0.4.0...v0.5.0) - 2026-06-12
+
+### Other
+
+- Use newtype pattern for `BarometricPressure` and `Altitude`
+
 ## [0.4.0](https://github.com/ghismary/weather-utils/compare/v0.3.0...v0.4.0) - 2026-06-10
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "weather-utils"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Ghislain MARY <ghislain@ghislainmary.fr>"]
 repository = "https://github.com/ghismary/weather-utils"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `weather-utils`: 0.4.0 -> 0.5.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/ghismary/weather-utils/compare/v0.4.0...v0.5.0) - 2026-06-12

### Other

- Use newtype pattern for `BarometricPressure` and `Altitude`
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).